### PR TITLE
fix: dont't print babashka.process exception from invoker

### DIFF
--- a/src/api/makejack/api/core.clj
+++ b/src/api/makejack/api/core.clj
@@ -14,13 +14,15 @@
   nil)
 
 (defn error
-  "Exit with the given error message.
-   Exits with error code 1,"
-  [s]
-  (binding [*out* *err*]
-    (println s))
-  (shutdown-agents)
-  (System/exit 1))
+  "Exit with the given error message and exit code.
+   The default exit-code is 1,"
+  ([message] (error message 1))
+  ([message exit-code]
+   (binding [*out* *err*]
+     (println message))
+   (shutdown-agents)
+   (System/exit exit-code)))
+
 
 (defn- load-deps* []
   (try

--- a/src/cli/makejack/impl/util.clj
+++ b/src/cli/makejack/impl/util.clj
@@ -1,0 +1,18 @@
+(ns makejack.impl.util
+  (:require [makejack.api.core :as makejack]))
+
+(defn maybe-string [x]
+  (if (string? x)
+    x))
+
+(defn handle-invoker-exception
+  [e]
+  (let [data (ex-data e)]
+    (if (= :babashka.process/error (:type data))
+      (makejack/error
+        (or
+          (maybe-string (:err data))
+          (maybe-string (:out data))
+          "Failed")
+        (:exit data 1))
+      (throw e))))

--- a/src/cli/makejack/invoke/babashka.clj
+++ b/src/cli/makejack/invoke/babashka.clj
@@ -1,6 +1,7 @@
 (ns makejack.invoke.babashka
   "Makejack tool to invoke babashka"
-  (:require [makejack.api.babashka :as babashka]))
+  (:require [makejack.api.babashka :as babashka]
+            [makejack.impl.util :as util]))
 
 (defn babashka
   "Invoke babashka"
@@ -20,15 +21,18 @@
                            forward-options?      (into ["-o" options])
                            (:args target-config) (into (:args target-config)))
         options          (merge options
-                                  (select-keys [:with-project-deps?] target-config))]
-    (babashka/process
-      aliases
-      deps
-      args
-      (merge
-        (if (seq args)
-          {}
-          {:out :inherit ; run a bb repl
-           :err :inherit
-           :in  :inherit})
-        options))))
+                                (select-keys [:with-project-deps?] target-config))]
+    (try
+      (babashka/process
+        aliases
+        deps
+        args
+        (merge
+          (if (seq args)
+            {}
+            {:out :inherit ; run a bb repl
+             :err :inherit
+             :in  :inherit})
+          options))
+      (catch clojure.lang.ExceptionInfo e
+        (util/handle-invoker-exception e)))))

--- a/src/cli/makejack/invoke/clojure.clj
+++ b/src/cli/makejack/invoke/clojure.clj
@@ -1,6 +1,7 @@
 (ns makejack.invoke.clojure
   "Makejack tool to invoke clojure"
-  (:require [makejack.api.clojure-cli :as clojure-cli]))
+  (:require [makejack.api.clojure-cli :as clojure-cli]
+            [makejack.impl.util :as util]))
 
 (def ^:private option-str->keyword
   {"-Sdeps" :sdeps
@@ -47,4 +48,7 @@
                                            true (into
                                                   (:main-args target-config)))})
                            args)]
-    (clojure-cli/process args options)))
+    (try
+      (clojure-cli/process args options)
+      (catch clojure.lang.ExceptionInfo e
+        (util/handle-invoker-exception e)))))

--- a/src/cli/makejack/invoke/shell.clj
+++ b/src/cli/makejack/invoke/shell.clj
@@ -1,12 +1,15 @@
 (ns makejack.invoke.shell
   "Makejack tool to invoke shell"
-  (:require [makejack.api.core :as makejack]))
+  (:require [makejack.api.core :as makejack]
+            [makejack.impl.util :as util]))
 
 (defn shell
   "Invoke shell command."
   [_args target-kw config _options]
   (let [target-config (get-in config [:mj :targets target-kw])
-        args          (:args target-config)
-        res           (makejack/process args (:options target-config))]
-    (if (pos? (:exit res))
-      (makejack/error "makejack.shell tool failed"))))
+        args          (:args target-config)]
+    (try
+      (makejack/process args (:options target-config))
+      nil
+      (catch clojure.lang.ExceptionInfo e
+        (util/handle-invoker-exception e)))))

--- a/src/cli/makejack/main.clj
+++ b/src/cli/makejack/main.clj
@@ -11,8 +11,9 @@
   (:gen-class))
 
 (defn apply-command [cmd args options]
-  (let [cmd        (read-string cmd)]
-    (run/run-command cmd args options)))
+  (let [cmd (read-string cmd)]
+    (run/run-command cmd args options)
+    nil))
 
 (defn error-msg [errors]
   (str "makejack error:\n" (str/join \newline errors)))


### PR DESCRIPTION
If the invoked process fails, forward the exit code, and output stderr
or stdout, if these have been captured as strings.