### PR TITLE
feat: add no-op invoker, and :undefined special target

### DIFF
--- a/src/cli/makejack/impl/invokers.clj
+++ b/src/cli/makejack/impl/invokers.clj
@@ -1,9 +1,11 @@
 (ns makejack.impl.invokers
   (:require makejack.invoke.babashka
             makejack.invoke.clojure
+            makejack.invoke.no-op
             makejack.invoke.shell))
 
 (def invokers
   {:babashka #'makejack.invoke.babashka/babashka
    :clojure  #'makejack.invoke.clojure/clojure
+   :no-op    #'makejack.invoke.no-op/no-op
    :shell    #'makejack.invoke.shell/shell})

--- a/src/cli/makejack/impl/run.clj
+++ b/src/cli/makejack/impl/run.clj
@@ -5,7 +5,8 @@
 (defn run-command [cmd args options]
   (let [config       (makejack/load-config {:profile (:profile options)})
         target-kw     (keyword cmd)
-        target        (resolve/resolve-target target-kw config)
+        target        (or (resolve/resolve-target target-kw config)
+                          (resolve/resolve-target :undefined config))
         f             (resolve/resolve-target-invoker target)]
     (when-not target
       (makejack/error (str "Unknown target: " cmd)))

--- a/src/cli/makejack/invoke/no_op.clj
+++ b/src/cli/makejack/invoke/no_op.clj
@@ -1,0 +1,14 @@
+(ns makejack.invoke.no-op)
+
+(defn no-op
+  "When the :message key is specified in the target config, prints the message.
+
+  Otherwise, does nothing.
+
+  Useful for specifying an :undefined target to make missing targets not be an error,
+  or as a no-op specification for a specific target."
+  [_args target-kw config _options]
+  (let [target-config (get-in config [:mj :targets target-kw])
+        message (:message target-config)]
+    (when message
+      (println message))))


### PR DESCRIPTION
Allow specification of no-op targets, which can be useful in a
multi-module project with targets that differ by module.