### PR TITLE
chore: factor out dispatch-main

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,6 @@
 {:linters {:missing-else-branch {:level :off}
-           :unused-binding      {:exclude-destructured-keys-in-fn-args true}}
+           :unused-binding      {:exclude-destructured-keys-in-fn-args true}
+           :unused-namespace    {:exclude [makejack.api.aero]}}
  :lint-as {makejack.api.filesystem/with-temp-dir  clojure.core/let
            makejack.api.filesystem/with-temp-path clojure.core/let}
  }

--- a/api/src/makejack/api/core.clj
+++ b/api/src/makejack/api/core.clj
@@ -180,8 +180,3 @@
   [& args]
   (when *verbose*
     (apply println args)))
-
-(defmacro with-makejack-tool [[tool-name options project] & body]
-  `(with-output-bindings [~options]
-     (verbose-println ~tool-name (project-description ~project))
-     ~@body))

--- a/api/src/makejack/api/default_config.clj
+++ b/api/src/makejack/api/default_config.clj
@@ -70,7 +70,8 @@
          :main      'makejack.tools.pom
          :main-args ["--profile" ":pom"]}
 
-   :jar {:doc       "Build a jar, "
+   :jar {:doc       "Build a jar.
+If `:jar-type` is `:uberjar`, then build an uberjar, else a thin jar."
          :invoker   :babashka
          :deps      mj-tools
          :main      'makejack.tools.jar

--- a/api/test/makejack/api/tool_test.clj
+++ b/api/test/makejack/api/tool_test.clj
@@ -1,0 +1,43 @@
+(ns makejack.api.tool-test
+  (:require [makejack.api.core :as makejack]
+            [makejack.api.tool :as tool]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest dispatch-main-test
+  (let [options  (volatile! nil)
+        args     (volatile! nil)
+        config   (volatile! nil)
+        bindings (volatile! nil)
+        tool-fn  (fn [options_ args_ config_]
+                   (vreset! options options_)
+                   (vreset! args args_)
+                   (vreset! config config_)
+                   (vreset! bindings {:verbose makejack/*verbose*
+                                      :debug   makejack/*debug*}))]
+    (testing "dispatch-main"
+      (testing "parses cli-options"
+        (tool/dispatch-main "" "" tool-fn [] ["--profile" "aprofile"])
+        (is (= 'aprofile (:profile @options))))
+      (testing "exits on unrecognised options"
+        (let [error (volatile! nil)]
+          (with-redefs [makejack/error (fn [message] (vreset! error message))]
+            (tool/dispatch-main "" "" tool-fn [] ["--xyz"])
+            (is @error))))
+      (testing "forwards un-parsed options and arguments"
+        (tool/dispatch-main "" "" tool-fn [] ["--profile" "p" "else" "--something"])
+        (is (= ["else" "--something"] @args)))
+      (testing "loads the mj.edn file in config"
+        (tool/dispatch-main "" "" tool-fn [] [])
+        (is (= "target" (-> @config :mj :target-path))))
+      (testing "loads the project.edn file in config"
+        (tool/dispatch-main "" "" tool-fn [] [])
+        (is (= "makejack" (-> @config :project :name))))
+      (testing "binds *verbose* and *debug* according to --verbose and --debug options"
+        (tool/dispatch-main "" "" tool-fn [] [])
+        (is (= {:verbose nil :debug nil} @bindings))
+        (tool/dispatch-main "" "" tool-fn [] ["--verbose"])
+        (is (= {:verbose true :debug nil} @bindings))
+        (tool/dispatch-main "" "" tool-fn [] ["--debug"])
+        (is (= {:verbose nil :debug true} @bindings))
+        (tool/dispatch-main "" "" tool-fn [] ["--debug" "--verbose"])
+        (is (= {:verbose true :debug true} @bindings))))))

--- a/cli/src/makejack/impl/help.clj
+++ b/cli/src/makejack/impl/help.clj
@@ -50,6 +50,8 @@
      ""
      summary
      ""
+     "Use mj help <target> for more detailed help on target."
+     ""
      "Project targets:"
      (target-doc)
      ""

--- a/tools/src/makejack/tools/compile.clj
+++ b/tools/src/makejack/tools/compile.clj
@@ -4,7 +4,7 @@
   (:require [makejack.api.clojure-cli :as clojure-cli]
             [makejack.api.core :as makejack]
             [makejack.api.filesystem :as filesystem]
-            [makejack.api.tool-options :as tool-options]
+            [makejack.api.tool :as tool]
             [makejack.api.util :as util]))
 
 (defn- compile-ns-form [ns-sym]
@@ -12,7 +12,7 @@
 
 (defn compile
   "AOT compilation of clojure sources."
-  [_args {:keys [mj project]} options]
+  [options _args {:keys [mj project]}]
   (let [aliases      (-> []
                          (into (:aliases project))
                          (into (:aliases options)))
@@ -48,12 +48,8 @@
 
 (def extra-options
   [["-a" "--aliases ALIASES" "Aliases to use."
-    :parse-fn tool-options/parse-kw-stringlist]])
+    :parse-fn tool/parse-kw-stringlist]])
 
 (defn -main [& args]
-  (let [{:keys [arguments options] {:keys [project] :as config} :config}
-        (tool-options/parse-options-and-apply-to-config
-         args extra-options "compile options")]
-    (makejack/with-makejack-tool ["compile" options project]
-      (compile arguments config options))
-    (shutdown-agents)))
+  (tool/with-shutdown-agents
+    (tool/dispatch-main "compile" "[options]" compile extra-options args)))

--- a/tools/src/makejack/tools/deploy.clj
+++ b/tools/src/makejack/tools/deploy.clj
@@ -6,7 +6,7 @@
             [makejack.api.core :as makejack]
             [makejack.api.filesystem :as filesystem]
             [makejack.api.path :as path]
-            [makejack.api.tool-options :as tool-options]
+            [makejack.api.tool :as tool]
             [makejack.api.util :as util]
             [org.httpkit.client :as client]
             [org.httpkit.sni-client :as sni-client])
@@ -229,7 +229,7 @@
 
 (defn deploy
   "Deploy a project to a maven repository."
-  [[repo-name] {:keys [mj project] :as _config} _options]
+  [_options [repo-name] {:keys [mj project] :as _config}]
   (let [repository  (repository repo-name)
         credentials (credentials repository)
         paths       (paths-to-deploy mj project)]
@@ -244,12 +244,8 @@
 
 (def extra-options
   [["-a" "--aliases ALIASES" "Aliases to use."
-    :parse-fn tool-options/parse-kw-stringlist]])
+    :parse-fn tool/parse-kw-stringlist]])
 
 (defn -main [& args]
-  (let [{:keys [arguments options] {:keys [project] :as config} :config}
-        (tool-options/parse-options-and-apply-to-config
-         args extra-options "pom [options]")]
-    (makejack/with-makejack-tool ["deploy" options project]
-      (deploy arguments config options))
-    (shutdown-agents)))
+  (tool/with-shutdown-agents
+    (tool/dispatch-main "deploy" "[options] [repo-name]" deploy extra-options args)))

--- a/tools/src/makejack/tools/graal_compile.clj
+++ b/tools/src/makejack/tools/graal_compile.clj
@@ -1,13 +1,13 @@
 (ns makejack.tools.graal-compile
   (:require [makejack.api.core :as makejack]
             [makejack.api.path :as path]
-            [makejack.api.tool-options :as tool-options]))
+            [makejack.api.tool :as tool]))
 
 (defn graal-compile
   "GraalVM native-image compilation of jar file.
   Specify options using .properties file in the uberjar.
   See https://www.graalvm.org/reference-manual/native-image/Configuration/."
-  [_args {:keys [mj project]} _options]
+  [_options _args {:keys [mj project]}]
   (when (= :jar (:jar-type project))
     (throw (ex-info
             "GraalVM compilation requires an uberjar"
@@ -33,9 +33,5 @@
   [])
 
 (defn -main [& args]
-  (let [{:keys [arguments options] {:keys [project] :as config} :config}
-        (tool-options/parse-options-and-apply-to-config
-         args extra-options "graal-compile options")]
-    (makejack/with-makejack-tool ["graalVM native-image" options project]
-      (graal-compile arguments config options))
-    (shutdown-agents)))
+  (tool/with-shutdown-agents
+    (tool/dispatch-main "graal-compile" "[options]" graal-compile extra-options args)))

--- a/tools/src/makejack/tools/init.clj
+++ b/tools/src/makejack/tools/init.clj
@@ -1,9 +1,8 @@
 (ns makejack.tools.init
   "Initialise project"
-  (:require [makejack.api.core :as makejack]
-            [makejack.api.filesystem :as filesystem]
+  (:require [makejack.api.filesystem :as filesystem]
             [makejack.api.path :as path]
-            [makejack.api.tool-options :as tool-options]))
+            [makejack.api.tool :as tool]))
 
 (def default-mj
   (tagged-literal 'mj {:targets (tagged-literal 'default-targets :all)}))
@@ -11,7 +10,7 @@
 (defn init
   "Initialise a project for use with makejack.
   Creates project.edn and mj.edn files if they do not exist.  "
-  [_args _config _options]
+  [_options _args _config]
   (when-not (filesystem/file-exists? "project,edn")
     (let [dir-name        (path/filename (filesystem/real-path (filesystem/cwd)))
           default-project {:name    (str dir-name)
@@ -24,10 +23,5 @@
   [])
 
 (defn -main [& args]
-  (let [{:keys [arguments config options]}
-        (tool-options/parse-options-and-apply-to-config
-         args extra-options "init [options]")]
-    (makejack/with-output-bindings [options]
-      (makejack/verbose-println "Initialise project for makejack")
-      (init arguments config options))
-    (shutdown-agents)))
+  (tool/with-shutdown-agents
+    (tool/dispatch-main "init" "[options]" init extra-options args)))

--- a/tools/src/makejack/tools/install.clj
+++ b/tools/src/makejack/tools/install.clj
@@ -2,10 +2,9 @@
   "Install to local repository"
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [makejack.api.core :as makejack]
             [makejack.api.filesystem :as filesystem]
             [makejack.api.path :as path]
-            [makejack.api.tool-options :as tool-options]
+            [makejack.api.tool :as tool]
             [makejack.api.util :as util])
   (:import [org.apache.maven.artifact.repository.metadata Metadata Versioning]
            [org.apache.maven.artifact.repository.metadata.io.xpp3
@@ -56,7 +55,7 @@
 
 (defn install
   "Install a project to a maven repository."
-  [_args {:keys [mj project] :as _config} _options]
+  [_options _args {:keys [mj project] :as _config}]
   (let [paths         (paths-to-install mj project)
         repo-home     (path/path (System/getProperty "user.home") ".m2" "repository")
         artifact-path (path/path repo-home (group-path project) (:name project))
@@ -68,12 +67,8 @@
 
 (def extra-options
   [["-a" "--aliases ALIASES" "Aliases to use."
-    :parse-fn tool-options/parse-kw-stringlist]])
+    :parse-fn tool/parse-kw-stringlist]])
 
 (defn -main [& args]
-  (let [{:keys [arguments options] {:keys [project] :as config} :config}
-        (tool-options/parse-options-and-apply-to-config
-         args extra-options "pom [options]")]
-    (makejack/with-makejack-tool ["Install" options project]
-      (install arguments config options))
-    (shutdown-agents)))
+  (tool/dispatch-main "install" "[options]" install extra-options args)
+  (shutdown-agents))

--- a/tools/src/makejack/tools/jar.clj
+++ b/tools/src/makejack/tools/jar.clj
@@ -1,14 +1,14 @@
 (ns makejack.tools.jar
   (:require [makejack.api.clojure-cli :as clojure-cli]
             [makejack.api.core :as makejack]
-            [makejack.api.tool-options :as tool-options]
+            [makejack.api.tool :as tool]
             [makejack.api.path :as path])
   (:gen-class))
 
 (defn depstar
   "Build a jar with depstar.
   If `:jar-type` is `:uberjar`, then build an uberjar, else a thin jar."
-  [_args {:keys [mj project] :as _config} options]
+  [options _args {:keys [mj project] :as _config}]
   (let [aliases         (-> []
                             (into (:aliases project))
                             (into (:aliases options)))
@@ -37,12 +37,8 @@
 
 (def extra-options
   [["-a" "--aliases ALIASES" "Aliases to use."
-    :parse-fn tool-options/parse-kw-stringlist]])
+    :parse-fn tool/parse-kw-stringlist]])
 
 (defn -main [& args]
-  (let [{:keys [arguments options] {:keys [project] :as config} :config}
-        (tool-options/parse-options-and-apply-to-config
-         args extra-options "jar [options]")]
-    (makejack/with-makejack-tool ["Jar" options project]
-      (depstar arguments config options))
-    (shutdown-agents)))
+  (tool/with-shutdown-agents
+    (tool/dispatch-main "jar" "[options]" depstar extra-options args)))

--- a/tools/src/makejack/tools/javac.clj
+++ b/tools/src/makejack/tools/javac.clj
@@ -3,12 +3,12 @@
             [makejack.api.clojure-cli :as clojure-cli]
             [makejack.api.core :as makejack]
             [makejack.api.filesystem :as filesystem]
-            [makejack.api.tool-options :as tool-options]
+            [makejack.api.tool :as tool]
             [makejack.api.util :as util]))
 
 (defn javac
   "Compile java sources."
-  [_args {:keys [mj project]} options]
+  [options _args {:keys [mj project]}]
   (let [java-paths    (:java-paths project)
         javac-options (:javac-options project)
         source-files  (->> java-paths
@@ -31,14 +31,8 @@
 
 (def extra-options
   [["-a" "--aliases ALIASES" "Aliases to use."
-    :parse-fn tool-options/parse-kw-stringlist]])
+    :parse-fn tool/parse-kw-stringlist]])
 
 (defn -main [& args]
-  (let [{:keys [arguments options] {:keys [project] :as config} :config}
-        (tool-options/parse-options-and-apply-to-config
-         args extra-options "javac [options]")]
-    (makejack/with-makejack-tool ["javac" options project]
-      (try
-        (javac arguments config options)
-        (finally
-          (shutdown-agents))))))
+  (tool/with-shutdown-agents
+    (tool/dispatch-main "javac" "[options]" javac extra-options args)))

--- a/tools/src/makejack/tools/pom.clj
+++ b/tools/src/makejack/tools/pom.clj
@@ -2,9 +2,8 @@
   "Create a pom file"
   (:require [clojure.java.io :as io]
             [makejack.api.clojure-cli :as clojure-cli]
-            [makejack.api.core :as makejack]
             [makejack.api.filesystem :as filesystem]
-            [makejack.api.tool-options :as tool-options])
+            [makejack.api.tool :as tool])
   (:import [org.apache.maven.model
             Build Model #_Scm]
            [org.apache.maven.model.io.xpp3
@@ -42,7 +41,7 @@
 
 (defn pom
   "Pom file creation or update."
-  [_args {:keys [mj project] :as _config} options]
+  [options _args {:keys [mj project] :as _config}]
   (let [aliases     (-> []
                         (into (:aliases project))
                         (into (:aliases options)))
@@ -64,12 +63,8 @@
 
 (def extra-options
   [["-a" "--aliases ALIASES" "Aliases to use."
-    :parse-fn tool-options/parse-kw-stringlist]])
+    :parse-fn tool/parse-kw-stringlist]])
 
 (defn -main [& args]
-  (let [{:keys [arguments options] {:keys [project] :as config} :config}
-        (tool-options/parse-options-and-apply-to-config
-         args extra-options "pom [options]")]
-    (makejack/with-makejack-tool ["pom" options project]
-      (pom arguments config options))
-    (shutdown-agents)))
+  (tool/with-shutdown-agents
+    (tool/dispatch-main "pom" "[options]" pom extra-options args)))

--- a/tools/src/makejack/tools/uberscript.clj
+++ b/tools/src/makejack/tools/uberscript.clj
@@ -3,11 +3,11 @@
             [makejack.api.core :as makejack]
             [makejack.api.filesystem :as filesystem]
             [makejack.api.path :as path]
-            [makejack.api.tool-options :as tool-options]))
+            [makejack.api.tool :as tool]))
 
 (defn uberscript
   "Output a babashka uberscript."
-  [_args {:keys [mj project] :as _config} options]
+  [options _args {:keys [mj project] :as _config}]
   (let [aliases     (-> []
                         (into (:aliases project))
                         (into (:aliases options)))
@@ -37,12 +37,8 @@
 
 (def extra-options
   [["-a" "--aliases ALIASES" "Aliases to use."
-    :parse-fn tool-options/parse-kw-stringlist]])
+    :parse-fn tool/parse-kw-stringlist]])
 
 (defn -main [& args]
-  (let [{:keys [arguments options] {:keys [project] :as config} :config}
-        (tool-options/parse-options-and-apply-to-config
-         args extra-options "uberscript [options]")]
-    (makejack/with-makejack-tool ["uberscript" options project]
-      (uberscript arguments config options))
-    (shutdown-agents)))
+  (tool/with-shutdown-agents
+    (tool/dispatch-main "uberscript" "[options]" uberscript extra-options args)))

--- a/tools/test/integration/java_test.clj
+++ b/tools/test/integration/java_test.clj
@@ -11,32 +11,42 @@
 
 (def mj-script "../../../cli/target/mj-script")
 
+(defn- process [args options]
+  (makejack/process
+   args
+   (merge
+    {:out :inherit
+     :err :inherit}
+    options)))
+
 (deftest java-test
   (testing "mj javac"
-    (makejack/process [mj-script "--verbose" "javac"]
-                      {:dir "test-resources/test_project_java"})
+    (process [mj-script "--verbose" "javac"]
+             {:dir "test-resources/test_project_java"
+              :out :inherit
+              :err :inherit})
     (let [class-file (path/path
                       "test-resources" "test_project_java"
                       "target" "classes" "my" "Hello.class")]
       (testing "creates class file"
         (is (filesystem/file-exists? class-file)))))
   (testing "mj compile"
-    (makejack/process [mj-script "--verbose" "compile"]
-                      {:dir "test-resources/test_project_java"})
+    (process [mj-script "--verbose" "compile"]
+             {:dir "test-resources/test_project_java"})
     (let [class-file (path/path
                       "test-resources" "test_project_java"
                       "target" "classes" "my" "main__init.class")]
       (testing "creates class file"
         (is (filesystem/file-exists? class-file)))))
   (testing "mj pom"
-    (makejack/process [mj-script "--verbose" "pom"]
-                      {:dir "test-resources/test_project_java"})
+    (process [mj-script "--verbose" "pom"]
+             {:dir "test-resources/test_project_java"})
     (let [pom-file (path/path "test-resources" "test_project_java" "pom.xml")]
       (testing "creates pom"
         (is (filesystem/file-exists? pom-file)))))
   (testing "mj uberjar"
-    (makejack/process [mj-script "--verbose" "uberjar"]
-                      {:dir "test-resources/test_project_java"})
+    (process [mj-script "--verbose" "uberjar"]
+             {:dir "test-resources/test_project_java"})
     (let [jar (path/path "test-resources" "test_project_java" "target"
                          "java-0.1.0-standalone.jar")]
       (testing "creates uberjar file"
@@ -51,13 +61,15 @@
         (with-open [jar-file (java.util.jar.JarFile. (str jar))]
           (is (.getJarEntry jar-file "my/Hello.class"))))
       (testing "can be invoked by clojure"
-        (let [res (makejack/process
+        (let [res (process
                    ["clojure" "-Scp" "target/java-0.1.0-standalone.jar"
                     "-m" "my.main" "world"]
-                   {:dir "test-resources/test_project_java"})]
+                   {:dir "test-resources/test_project_java"
+                    :out :string})]
           (is (= "Hello world\n" (:out res)))))
       (testing "can be invoked by java"
-        (let [res (makejack/process
+        (let [res (process
                    ["java" "-jar" "target/java-0.1.0-standalone.jar" "world"]
-                   {:dir "test-resources/test_project_java"})]
+                   {:dir "test-resources/test_project_java"
+                    :out :string})]
           (is (= "Hello world\n" (:out res))))))))

--- a/tools/test/unit/makejack/tools/jar_test.clj
+++ b/tools/test/unit/makejack/tools/jar_test.clj
@@ -8,6 +8,6 @@
   (filesystem/with-temp-dir [dir "jat-test"]
     (filesystem/mkdirs (path/path dir "src"))
     (spit (str (path/path dir "src" "my.ns")) (str '(ns my)))
-    (jar/depstar [] {:mj {:target-path (str dir)}
-                     :project {:jar-name "my-0.1.0.jar"}} {})
+    (jar/depstar {} [] {:mj      {:target-path (str dir)}
+                        :project {:jar-name "my-0.1.0.jar"}})
     (is (filesystem/file-exists? (path/path dir "my-0.1.0.jar")))))

--- a/tools/test/unit/makejack/tools/pom_test.clj
+++ b/tools/test/unit/makejack/tools/pom_test.clj
@@ -2,5 +2,5 @@
   (:require [clojure.test :refer [deftest is]]
             [makejack.tools.pom :as pom]))
 
-(deftest compile-test
+(deftest pom-test
   (is pom/pom))


### PR DESCRIPTION
Factor out common code from tool implementations.

- Renames tool-options namespace to tool
- Adds dispatch-main function
- Adds with-shutdown-agents macro